### PR TITLE
Add debugger

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,8 @@ class EventsController < ApplicationController
 
   def create
     @event = event
+    require 'pry'; binding.pry
+
     if @event.save
       redirect_to :index
     else


### PR DESCRIPTION
So the create test looks well written, the problem is that create isn't doing what you expect.

I added a debugger in the create action on your events controller:

![image](https://cloud.githubusercontent.com/assets/270746/26287338/34df23e6-3e2e-11e7-8d90-36dc59b70d29.png)

You're setting `@event` to `event` and `event` is a new, empty event object. I think what you want to do is set some attributes on your new event and then set `@event`.

```
def create
  @event = Event.new(event_params)
  # ...
end
```

You're also going to need to deal with [strong parameters from Rails](http://edgeguides.rubyonrails.org/action_controller_overview.html#strong-parameters):

```
private

def event_params
  params.permit(:id, :event_name, :event_date, :event_time)
end
```

Would also suggest that you remove the `event_` prefix from your attribute names. We know it's an event name because it's an attribute on an event. Maybe go with :name, :start_date, :start_time.

To change a column name with a Rails migration generate a new migration:

```
rails g migration change_event_event_name_to_name
```

and then add this line in the change method:

```
rename_column :table, :old_column, :new_column
```

I'm not sure what format your datepicker is giving you for a datetime but it likely looks something like this string: `"2017-07-08 09:10:00 -0700"`. That's the datetime from FactoryGirl so if the string your datepicker makes is significantly different you may have to adjust the string format. Most likely `DateTime.parse` will know how to handle it:

```
irb(main):004:0> DateTime.parse "2017-07-08 09:10:00 -0700"
=> Sat, 08 Jul 2017 09:10:00 -0700
```

If the string is formatted correctly ActiveRecord will actually save it just fine:

```
irb(main):010:0> time = Time.now.to_s # note the to_s
=> 2017-05-21 14:15:08 -0700
irb(main):011:0> date = Date.today.to_s
=> Sun, 21 May 2017
irb(main):012:0> Event.create(event_name: "test", event_date: date, event_time: time)
   (0.2ms)  BEGIN
  SQL (2.3ms)  INSERT INTO "events" ("event_name", "event_date", "event_time", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["event_name", "test"], ["event_date", "2017-05-21"], ["event_time", "22:15:08.634986"], ["created_at", "2017-05-21 21:15:38.729810"], ["updated_at", "2017-05-21 21:15:38.729810"]]
   (0.4ms)  COMMIT
=> #<Event id: 1, event_name: "test", event_date: "2017-05-21", event_time: "2000-01-01 22:15:08", created_at: "2017-05-21 21:15:38", updated_at: "2017-05-21 21:15:38">
```

You also probably want to use a datetime attribute to save both the time and date as a single attribute on your events. If you tell the migration generator the name of the attribute you want to remove and name your migration with the pattern "remove_ATTRIBUTE_from_TABLE" then Rails will generate the change method automatically for you:

```
$ rails g migration remove_event_time_from_events event_time:time
      invoke  active_record
      create    db/migrate/20170521212612_remove_event_time_from_events.rb
$ cat db/migrate/20170521212612_remove_event_time_from_events.rb
class RemoveEventTimeFromEvents < ActiveRecord::Migration[5.0]
  def change
    remove_column :events, :event_time, :time
  end
end
```

So use that to remove your two event time and date columns and add a new attribute called start:

```
rails g migration add_start_to_events start:datetime
```

Which automatically generates this:

```
class AddStartToEvents < ActiveRecord::Migration[5.0]
  def change
    add_column :events, :start, :datetime
  end
end
```

You can read more about changing tables and naming migrations for automatic change method generation in the [Rails documentation](http://edgeguides.rubyonrails.org/active_record_migrations.html#changing-tables).

You may also want to add `null: false` on the end of that `start` attribute. If you know an event will always have a start it's considered a best practice to make sure you have it set at the database level. You can and should use a model validation on this attribute as well to make sure it's present, but setting null to false here will prevent and object from saving to the database with invalid data.

Of course if you want to be able to make events with null starts then you should leave this off, just wanted to let you know about the option.

Best,

Jonan